### PR TITLE
Split SoundEffectManager from AudioManager.

### DIFF
--- a/framework/src/main/java/org/toop/framework/audio/AudioEventListener.java
+++ b/framework/src/main/java/org/toop/framework/audio/AudioEventListener.java
@@ -7,6 +7,10 @@ import org.toop.framework.audio.interfaces.VolumeManager;
 import org.toop.framework.eventbus.EventFlow;
 import org.toop.framework.resource.types.AudioResource;
 
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.IOException;
+
 public class AudioEventListener<T extends AudioResource, K extends AudioResource> {
     private final MusicManager<T> musicManager;
     private final SoundEffectManager<K> soundEffectManager;
@@ -33,7 +37,10 @@ public class AudioEventListener<T extends AudioResource, K extends AudioResource
                 .listen(this::handleMusicVolumeChange)
                 .listen(this::handleGetVolume)
                 .listen(this::handleGetFxVolume)
-                .listen(this::handleGetMusicVolume);
+                .listen(this::handleGetMusicVolume)
+                .listen(AudioEvents.ClickButton.class, _ -> {
+                    soundEffectManager.play("medium-button-click.wav", false);
+                });
     }
 
     private void handleStopMusicManager(AudioEvents.StopAudioManager event) {
@@ -45,7 +52,7 @@ public class AudioEventListener<T extends AudioResource, K extends AudioResource
     }
 
     private void handleStopSound(AudioEvents.StopEffect event) {
-        this.soundEffectManager.stop(event.clipId());
+        this.soundEffectManager.stop(event.fileName());
     }
 
     private void handleMusicStart(AudioEvents.StartBackgroundMusic event) {

--- a/framework/src/main/java/org/toop/framework/audio/SoundEffectManager.java
+++ b/framework/src/main/java/org/toop/framework/audio/SoundEffectManager.java
@@ -1,27 +1,64 @@
 package org.toop.framework.audio;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.toop.framework.resource.ResourceManager;
+import org.toop.framework.resource.ResourceMeta;
+import org.toop.framework.resource.resources.BaseResource;
 import org.toop.framework.resource.resources.SoundEffectAsset;
 
+import javax.sound.sampled.Clip;
+import javax.sound.sampled.LineEvent;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class SoundEffectManager implements org.toop.framework.audio.interfaces.SoundEffectManager<SoundEffectAsset> {
-    private final Map<Long, SoundEffectAsset> activeSoundEffects = new HashMap<>();
-    private final HashMap<String, SoundEffectAsset> audioResources = new HashMap<>();
+    private static final Logger logger = LogManager.getLogger(SoundEffectManager.class);
+    private final HashMap<String, SoundEffectAsset> soundEffectResources;
+
+    public SoundEffectManager(){
+        // If there are duplicates, takes discards the first
+        soundEffectResources = ResourceManager.getAllOfType(SoundEffectAsset.class).stream()
+                .collect(Collectors.toMap(ResourceMeta::getName, ResourceMeta::getResource, (a, b) -> b, HashMap::new));
+
+    }
 
     @Override
     public Collection<SoundEffectAsset> getActiveAudio() {
-        return this.audioResources.values();
+        return this.soundEffectResources.values();
     }
 
     @Override
     public void play(String name, boolean loop) {
-        //TODO
+        SoundEffectAsset asset = soundEffectResources.get(name);
+
+        if (asset == null) {
+            logger.warn("Unable to load audio asset: {}", name);
+            return;
+        }
+
+        asset.play();
+        // TODO: Volume of Sound Effect isn't set when loading. When loading an effect it will be full volume.
+        logger.debug("Playing sound: {}", asset.getFile().getName());
     }
 
     @Override
-    public void stop(long clipId) {
-        //TODO
+    public void stop(String name){
+        SoundEffectAsset asset = soundEffectResources.get(name);
+
+        if (asset == null) {
+            logger.warn("Unable to load audio asset: {}", name);
+            return;
+        }
+
+        asset.stop();
+
+        logger.debug("Stopped sound: {}", asset.getFile().getName());
     }
 }

--- a/framework/src/main/java/org/toop/framework/audio/events/AudioEvents.java
+++ b/framework/src/main/java/org/toop/framework/audio/events/AudioEvents.java
@@ -11,7 +11,7 @@ public class AudioEvents extends EventsBase {
     /** Starts playing a sound. */
     public record PlayEffect(String fileName, boolean loop) implements EventWithoutSnowflake {}
 
-    public record StopEffect(long clipId) implements EventWithoutSnowflake {}
+    public record StopEffect(String fileName) implements EventWithoutSnowflake {}
 
     public record StartBackgroundMusic() implements EventWithoutSnowflake {}
 

--- a/framework/src/main/java/org/toop/framework/audio/interfaces/SoundEffectManager.java
+++ b/framework/src/main/java/org/toop/framework/audio/interfaces/SoundEffectManager.java
@@ -3,7 +3,11 @@ package org.toop.framework.audio.interfaces;
 import org.toop.framework.resource.resources.SoundEffectAsset;
 import org.toop.framework.resource.types.AudioResource;
 
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.IOException;
+
 public interface SoundEffectManager<T extends AudioResource> extends AudioManager<T> {
     void play(String name, boolean loop);
-    void stop(long clipId);
+    void stop(String name);
 }


### PR DESCRIPTION
Clips no longer create a new clip instance each time they are played.  A singular clip is made for each resource and is opened/closed when loaded/unloaded. When a clip is played that is already playing it'll stop playback and start again. Clip volume handling isn't done very well.